### PR TITLE
Fix UniConn bufferSize bug and implementment of close read unit test

### DIFF
--- a/mockconn.go
+++ b/mockconn.go
@@ -6,15 +6,17 @@ import (
 )
 
 // The config to mock out an connection
-// A connection has two address represent two end points Addr1 and Addr2.
+// A connection has two address represent two endpoints Addr1 and Addr2.
 // Here we refer them as Addr1 and Addr2. They can be any string you would like.
 type ConnConfig struct {
-	Addr1      string
-	Addr2      string
-	Throughput uint
-	BufferSize uint
-	Latency    time.Duration
-	Loss       float32 // 0.01 = 1%
+	Addr1        string        // endpoint 1 address
+	Addr2        string        // endpoint 2 address
+	Throughput   uint          // throughput by packets/second
+	BufferSize   uint          // BufferSize used int connection. If it is not set, a default value will be computed.
+	Latency      time.Duration // Latency is the duration which the packet travels from endpoint 1 to endpoint 2.
+	Loss         float32       // loss rate, 0.01 = 1%
+	WriteTimeout time.Duration // set default timeout for writing, without timeout if zero
+	ReadTimeout  time.Duration // set default timeout for reading, without timeout if zero
 }
 
 // Mock network connection

--- a/mockconn_test.go
+++ b/mockconn_test.go
@@ -1,74 +1,14 @@
 package mockconn
 
 import (
-	"encoding/binary"
+	"fmt"
 	"log"
 	"math"
-	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-func WritePacktes(writer net.Conn, nPackets int, latency time.Duration, ch chan []int64) {
-	var sendSeq []int64
-
-	seq := int64(1)
-	count := int64(0)
-	t1 := time.Now()
-	for i := 0; i < nPackets; i++ {
-		b := make([]byte, 1024)
-		binary.PutVarint(b, seq)
-		_, err := writer.Write(b)
-		if err != nil {
-			break
-		}
-		sendSeq = append(sendSeq, seq)
-		seq++
-		count++
-	}
-	dur := time.Since(t1)
-	throughput := float64(count) / dur.Seconds()
-
-	log.Printf("%v send %v packets in %v ms, throughput is: %.1f packets/s \n",
-		writer.LocalAddr(), count, dur.Milliseconds(), throughput)
-
-	ch <- sendSeq
-
-	return
-}
-
-func ReadPackets(reader net.Conn, nPackets int, latency time.Duration, ch chan []int64) {
-	var recvSeq []int64
-
-	b := make([]byte, 1024)
-	count := int64(0)
-	t1 := time.Now()
-	for i := 0; i < nPackets; i++ {
-		_, err := reader.Read(b)
-		if err != nil {
-			break
-		}
-		seq, _ := binary.Varint(b[:8])
-		recvSeq = append(recvSeq, seq)
-		count++
-	}
-	dur := time.Since(t1)
-	dur2 := dur - latency
-	throughput := float64(count) / dur2.Seconds()
-
-	log.Printf("%v read %v packets in %v ms, deduct %v ms latency, throughput is: %.1f packets/s \n",
-		reader.LocalAddr(), count, dur.Milliseconds(), latency.Milliseconds(), throughput)
-	nc, ok := reader.(*NetConn)
-	if ok {
-		nc.PrintMetrics()
-	}
-
-	ch <- recvSeq
-
-	return
-}
 
 // go test -v -run=TestBidirection
 func TestBidirection(t *testing.T) {
@@ -81,12 +21,12 @@ func TestBidirection(t *testing.T) {
 	require.NotNil(t, bobConn)
 	require.Nil(t, err)
 
-	// left write to right
+	// Alice send to Bob
 	nPackets := 100
 	i := 0
 	sendChan := make(chan []int64)
 	recvChan := make(chan []int64)
-	go WritePacktes(aliceConn, nPackets, conf.Latency, sendChan)
+	go WritePacktes(aliceConn, nPackets, sendChan)
 	go ReadPackets(bobConn, nPackets, conf.Latency, recvChan)
 
 	sendSeq := <-sendChan
@@ -104,9 +44,9 @@ func TestBidirection(t *testing.T) {
 			aliceConn.LocalAddr(), bobConn.LocalAddr(), nPackets, bobConn.LocalAddr(), nPackets)
 	}
 
-	// right write to left
+	// Bob send to Alice
 	nPackets = 50
-	go WritePacktes(bobConn, nPackets, conf.Latency, sendChan)
+	go WritePacktes(bobConn, nPackets, sendChan)
 	go ReadPackets(aliceConn, nPackets, conf.Latency, recvChan)
 
 	sendSeq = <-sendChan
@@ -125,44 +65,29 @@ func TestBidirection(t *testing.T) {
 	}
 }
 
-// go test -v -run=TestLowThroughput
-func TestLowThroughput(t *testing.T) {
-	conf := &ConnConfig{Addr1: "Alice", Addr2: "Bob", Throughput: uint(16), Latency: 20 * time.Millisecond}
-	log.Printf("Going to test low throughput at %v packets/s, latency %v\n", conf.Throughput, conf.Latency)
+// go test -v -run=TestNetConnThroughput
+func TestNetConnThroughput(t *testing.T) {
+	tpBase := uint(256)
+	for i := 1; i <= 4; i++ {
+		tp := tpBase * uint(i)
+		conf := &ConnConfig{Addr1: "Alice", Addr2: "Bob", Throughput: tp, Latency: 20 * time.Millisecond}
+		log.Printf("Going to test throughput at %v packets/s, latency %v\n", conf.Throughput, conf.Latency)
 
-	aliceConn, bobConn, err := NewMockConn(conf)
-	require.NotNil(t, aliceConn)
-	require.NotNil(t, bobConn)
-	require.Nil(t, err)
+		aliceConn, bobConn, err := NewMockConn(conf)
+		require.NotNil(t, aliceConn)
+		require.NotNil(t, bobConn)
+		require.Nil(t, err)
 
-	nPackets := 256
-	sendChan := make(chan []int64)
-	recvChan := make(chan []int64)
-	go WritePacktes(aliceConn, nPackets, conf.Latency, sendChan)
-	go ReadPackets(bobConn, nPackets, conf.Latency, recvChan)
+		nPackets := 256
+		sendChan := make(chan []int64)
+		recvChan := make(chan []int64)
+		go WritePacktes(aliceConn, nPackets, sendChan)
+		go ReadPackets(bobConn, nPackets, conf.Latency, recvChan)
 
-	<-sendChan
-	<-recvChan
-}
-
-// go test -v -run=TestHighThroughput
-func TestHighThroughput(t *testing.T) {
-	conf := &ConnConfig{Addr1: "Alice", Addr2: "Bob", Throughput: uint(2048), Latency: 20 * time.Millisecond}
-	log.Printf("Going to test high throughput at %v packets/s, latency %v\n", conf.Throughput, conf.Latency)
-
-	aliceConn, bobConn, err := NewMockConn(conf)
-	require.NotNil(t, aliceConn)
-	require.NotNil(t, bobConn)
-	require.Nil(t, err)
-
-	nPackets := 2048
-	sendChan := make(chan []int64)
-	recvChan := make(chan []int64)
-	go WritePacktes(aliceConn, nPackets, conf.Latency, sendChan)
-	go ReadPackets(bobConn, nPackets, conf.Latency, recvChan)
-
-	<-sendChan
-	<-recvChan
+		<-sendChan
+		<-recvChan
+		fmt.Println()
+	}
 }
 
 // go test -v -run=TestHighLatency
@@ -178,7 +103,7 @@ func TestHighLatency(t *testing.T) {
 	nPackets := 256
 	sendChan := make(chan []int64)
 	recvChan := make(chan []int64)
-	go WritePacktes(aliceConn, nPackets, conf.Latency, sendChan)
+	go WritePacktes(aliceConn, nPackets, sendChan)
 	go ReadPackets(bobConn, nPackets, conf.Latency, recvChan)
 
 	<-sendChan
@@ -198,7 +123,7 @@ func TestLoss(t *testing.T) {
 	nPackets := 256
 	sendChan := make(chan []int64)
 	recvChan := make(chan []int64)
-	go WritePacktes(aliceConn, nPackets, conf.Latency, sendChan)
+	go WritePacktes(aliceConn, nPackets, sendChan)
 	go ReadPackets(bobConn, nPackets, conf.Latency, recvChan)
 
 	<-sendChan

--- a/pub_test.go
+++ b/pub_test.go
@@ -1,0 +1,64 @@
+package mockconn
+
+import (
+	"encoding/binary"
+	"log"
+	"net"
+	"time"
+)
+
+func WritePacktes(writer net.Conn, nPackets int, sendCh chan []int64) {
+	var sendSeq []int64
+
+	seq := int64(1)
+	count := int64(0)
+	t1 := time.Now()
+	for i := 0; i < nPackets; i++ {
+		b := make([]byte, 1024)
+		binary.PutVarint(b, seq)
+		_, err := writer.Write(b)
+		if err != nil {
+			break
+		}
+		sendSeq = append(sendSeq, seq)
+		seq++
+		count++
+	}
+	dur := time.Since(t1)
+	throughput := float64(count) / dur.Seconds()
+	log.Printf("%v send %v packets in %v ms, throughput is: %.1f packets/s \n",
+		writer.LocalAddr(), count, dur.Milliseconds(), throughput)
+
+	sendCh <- sendSeq // return the sequences written
+}
+
+func ReadPackets(reader net.Conn, nPackets int, latency time.Duration, recvCh chan []int64) {
+	var recvSeq []int64
+
+	b := make([]byte, 1024)
+	count := int64(0)
+	t1 := time.Now()
+	for i := 0; i < nPackets; i++ {
+		_, err := reader.Read(b)
+		if err != nil {
+			break
+		}
+		seq, _ := binary.Varint(b[:8])
+		recvSeq = append(recvSeq, seq)
+		count++
+	}
+	dur := time.Since(t1)
+	dur2 := dur - latency
+	throughput := float64(count) / dur2.Seconds()
+
+	log.Printf("%v read %v packets in %v ms, deduct %v ms latency, throughput is: %.1f packets/s \n",
+		reader.LocalAddr(), count, dur.Milliseconds(), latency.Milliseconds(), throughput)
+
+	if uc, ok := reader.(*UniConn); ok {
+		uc.PrintMetrics()
+	} else if nc, ok := reader.(*NetConn); ok {
+		nc.PrintMetrics()
+	}
+
+	recvCh <- recvSeq // return the sequences read
+}

--- a/uniconn_test.go
+++ b/uniconn_test.go
@@ -10,6 +10,28 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// go test -v -run=TestUniConnThroughput
+func TestUniConnThroughput(t *testing.T) {
+	tpBase := uint(256)
+	for i := 1; i <= 4; i++ {
+		tp := tpBase * (uint)(i)
+		conf := &ConnConfig{Addr1: "Alice", Addr2: "Bob", Throughput: tp, Latency: 20 * time.Millisecond}
+		uc, err := NewUniConn(conf)
+		require.Nil(t, err)
+		require.NotNil(t, uc)
+
+		fmt.Println("target tp is", tp)
+		sendChan := make(chan []int64)
+		recvChan := make(chan []int64)
+		nPacket := 100
+		go WritePacktes(uc, nPacket, sendChan)
+		go ReadPackets(uc, nPacket, conf.Latency, recvChan)
+
+		<-sendChan
+		<-recvChan
+	}
+}
+
 // go test -v -run=TestSetReadDeadline
 func TestSetReadDeadline(t *testing.T) {
 	conf := &ConnConfig{Addr1: "Alice", Addr2: "Bob", Throughput: uint(16), Latency: 100 * time.Millisecond}
@@ -17,11 +39,18 @@ func TestSetReadDeadline(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, uc)
 
-	uc.SetDeadline(time.Now().Add(time.Second))
-	b := make([]byte, 1500)
+	uc.SetReadDeadline(time.Now().Add(time.Second))
+	b := make([]byte, 1024)
 	n, err := uc.Read(b)
+	require.NotNil(t, err)
 	require.Equal(t, 0, n)
-	t.Log("Read with deadline, err: ", err)
+
+	n, err = uc.Write(b)
+	require.Nil(t, err)
+	require.Equal(t, 1024, n)
+	n, err = uc.Read(b)
+	require.Nil(t, err)
+	require.Equal(t, 1024, n)
 }
 
 // go test -v -run=TestClose
@@ -70,4 +99,81 @@ func TestRateLimiter(t *testing.T) {
 
 	fmt.Printf("Count %v took %v, average is %.1f, expected is %v\n",
 		count, d, float64(count)/d.Seconds(), lim)
+}
+
+// go test -v -run=TestCloseRead
+func TestCloseRead(t *testing.T) {
+	conf := &ConnConfig{Addr1: "Alice", Addr2: "Bob", Throughput: uint(16), Latency: 50 * time.Millisecond, WriteTimeout: 3 * time.Second}
+	uc, err := NewUniConn(conf)
+	require.Nil(t, err)
+	require.NotNil(t, uc)
+
+	writeCh := make(chan struct{})
+	go func() {
+		i := 0
+		for i = 0; i < 1000; i++ {
+			b := make([]byte, 1024)
+			n, err := uc.Write(b)
+			if err != nil {
+				t.Log("write err", err)
+				break
+			} else {
+				require.Equal(t, n, len(b))
+			}
+		}
+		close(writeCh)
+	}()
+
+	go func() {
+		i := 0
+		for i = 0; i < 1000; i++ {
+			b := make([]byte, 1024)
+			n, err := uc.Read(b)
+			if err != nil {
+				t.Log("read err", err)
+				break
+			} else {
+				require.Equal(t, n, len(b))
+			}
+
+			if i == 100 {
+				err := uc.CloseRead()
+				if err != nil {
+					t.Log("CloseRead err", err)
+				}
+			}
+		}
+		require.Equal(t, 101, i)
+	}()
+
+	<-writeCh
+}
+
+// go test -v -run=TestTimeout
+func TestTimeout(t *testing.T) {
+	conf := &ConnConfig{Addr1: "Alice", Addr2: "Bob", Throughput: uint(16), Latency: 20 * time.Millisecond,
+		WriteTimeout: 2 * time.Second, ReadTimeout: 3 * time.Second}
+	uc, err := NewUniConn(conf)
+	require.Nil(t, err)
+	require.NotNil(t, uc)
+
+	for i := 0; i < 1000; i++ {
+		b := []byte("hello")
+		n, err := uc.Write(b)
+		if err != nil {
+			require.Equal(t, 0, n)
+			require.Equal(t, context.DeadlineExceeded, err)
+			break
+		}
+	}
+
+	for i := 0; i < 1000; i++ {
+		b := make([]byte, 1024)
+		n, err := uc.Read(b)
+		if err != nil {
+			require.Equal(t, 0, n)
+			require.Equal(t, context.DeadlineExceeded, err)
+			break
+		}
+	}
 }


### PR DESCRIPTION
1. Fix bug of UniConn bufferSize 
2. Rest readCtx and writeCtx after Deadline expired
3. Implement of CloseRead and CloseWrite of NetConn
4. Arrangement of unit public functions

Signed-off-by: billfort <fxbao@hotmail.com>